### PR TITLE
Performance improvement idea for cardinality constraint encoders

### DIFF
--- a/cscl/cardinality_constraint_encoders.py
+++ b/cscl/cardinality_constraint_encoders.py
@@ -8,7 +8,7 @@ from cscl.interfaces import CNFLiteralFactory
 import itertools
 
 
-def subsets_of_size_k(collection, k):
+def subsets_of_size_k(collection: list, k: int):
     """
     Computes all subsets of size k.
 
@@ -16,27 +16,8 @@ def subsets_of_size_k(collection, k):
     :param k: A non-negative integer.
     :return: A list containing all size-k subsets of collection.
     """
-    # Potential optimization: make this a generator
-
-    assert(k >= 0)
-
-    # Base cases:
-    if k > len(collection):
-        return []
-    if k == 0:
-        return [[]]
-    if k == len(collection):
-        return [collection]
-
-    next_smaller_subsets = subsets_of_size_k(collection[1:], k-1)
-    next_subsets = subsets_of_size_k(collection[1:], k)
-
-    def extend_list(lst, item):
-        lst_copy = lst[:]
-        lst_copy.append(item)
-        return lst_copy
-
-    return next_subsets + list(map(lambda x: extend_list(x, collection[0]), next_smaller_subsets))
+    
+    return map(list, itertools.combinations(collection, k))
 
 
 def encode_at_most_k_constraint_binomial(lit_factory: CNFLiteralFactory, k: int, constrained_lits: list):

--- a/cscl/cardinality_constraint_encoders.py
+++ b/cscl/cardinality_constraint_encoders.py
@@ -34,10 +34,7 @@ def encode_at_most_k_constraint_binomial(lit_factory: CNFLiteralFactory, k: int,
     :return: The constraint in CNF clausal form, a list of lists of literals.
     """
 
-    result = []
-    for subset in subsets_of_size_k(constrained_lits, k+1):
-        result.append(list(map(lambda x: -x, subset)))
-    return result
+    return subsets_of_size_k([ -x for x in constrained_lits], k+1)
 
 
 def encode_at_most_k_constraint_ltseq(lit_factory: CNFLiteralFactory, k: int, constrained_lits: list):
@@ -189,7 +186,7 @@ def encode_at_most_k_constraint_commander(lit_factory: CNFLiteralFactory, k: int
     for idx, group in enumerate(groups):
         group_with_commanders = group + [-c for c in commanders[idx]]
         group_constraints += encode_exactly_k_constraint(lit_factory, k, group_with_commanders,
-                                                         encode_at_most_k_constraint_binomial)
+                                                         list(encode_at_most_k_constraint_binomial))
 
     # Break symmetries by ordering the commander literals:
     order_commanders = [[-group_commanders[i], group_commanders[i+1]]


### PR DESCRIPTION
Improves `encode_at_most_k_constraint_binomial` execution speed while keeping the output the same:
* `itertools.combinations` is faster than the custom implementation.
* Negating the input of `subsets_of_size_k` is faster than negating the output, as the input is smaller.

`encode_at_most_k_constraint_binomial(...)` is now a generator. Some callers expect the return value to be a list, the call needs to be wrapped in `list(encode_at_most_k_constraint_binomial(...))` there. I did not integrate these changes with other parts of the code, I expect there are additional places where this needs to happen, so **this PR can not be merged without some adjustments** but may be useful to some.